### PR TITLE
Project slug in URL

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,6 +5,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    @project = Project.find(params[:id])
+    @project = Project.find_by(slug: params[:id])
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ActiveRecord::Base
                        presence: true,
                        content_type: { content_type: /png\Z/ }
   validates :role, presence: true
+  validates :slug, presence: true, uniqueness: true
   validates :title, presence: true, uniqueness: true
   validates :website, presence: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,4 +14,8 @@ class Project < ActiveRecord::Base
 
   scope :featured, lambda { where.not(featured_at: nil) }
   scope :regular, lambda { where(featured_at: nil) }
+
+  def to_param
+    slug
+  end
 end

--- a/db/migrate/20160120203924_add_slug_to_projects.rb
+++ b/db/migrate/20160120203924_add_slug_to_projects.rb
@@ -1,0 +1,6 @@
+class AddSlugToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :slug, :string
+    add_index :projects, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151112215012) do
+ActiveRecord::Schema.define(version: 20160120203924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,8 +28,10 @@ ActiveRecord::Schema.define(version: 20151112215012) do
     t.string   "website"
     t.text     "description"
     t.datetime "featured_at"
+    t.string   "slug"
   end
 
+  add_index "projects", ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
   add_index "projects", ["title"], name: "index_projects_on_title", unique: true, using: :btree
 
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -23,10 +23,13 @@ RSpec.describe ProjectsController do
 
   describe '#show' do
     it 'assigns the right project to @project' do
-      project = double(:project, id: 1)
-      allow(Project).to receive(:find).and_return(project)
+      slug = 'project-1'
+      project = double(:project, slug: slug)
+      allow(Project).to receive(:find_by).
+                        with(hash_including(slug: slug)).
+                        and_return(project)
 
-      get :show, id: project.id
+      get :show, id: slug
 
       expect(assigns[:project]).to eq(project)
     end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
       fixture_file_upload(file_path, 'image/png')
     end
     sequence(:title) { |n| "Project #{n}" }
+    sequence(:slug) { |n| "project-#{n}" }
     role { [:design, :development, :everything].sample }
     website 'http://example.com'
     description <<-DESC.strip_heredoc

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Project do
     it { should validate_attachment_presence(:logo) }
     it { should validate_presence_of :description }
     it { should validate_presence_of :role }
+    it { should validate_presence_of :slug }
+    it { should validate_uniqueness_of :slug }
     it { should validate_presence_of :title }
     it { should validate_uniqueness_of :title }
     it { should validate_presence_of :website }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe Project do
       expect(Project.regular).to match_array(regular)
     end
   end
+
+  describe '.to_param' do
+    it 'uses the slug' do
+      slug = 'pull-feed'
+      project = build(:project, slug: slug)
+
+      expect(project.to_param).to eq(slug)
+    end
+  end
 end


### PR DESCRIPTION
This adds project slugs and makes them accessible by their URL. For example:

```
/projects/pull-feed
```

Instead of

```
/projects/1
```