### PR TITLE
Adjust for long project titles

### DIFF
--- a/app/assets/stylesheets/_featured-projects.scss
+++ b/app/assets/stylesheets/_featured-projects.scss
@@ -8,7 +8,8 @@
   border: $border;
   cursor: pointer;
   flex-direction: column;
-  height: 260px;
+  min-height: 260px;
+  padding: $base-spacing 1ex;
   margin-bottom: $base-spacing;
 
   @include media($desktop) {
@@ -22,7 +23,7 @@
   }
 
   h3 {
-    margin-bottom: $base-spacing;
+    margin-top: $base-spacing;
     text-align: center;
 
     a {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,8 +6,6 @@ module ApplicationHelper
   def project_logo(project)
     image_tag(project.logo.url(:standard),
               srcset: "#{project.logo.url} 2x",
-              width: Project::LOGO_SIZE,
-              height: Project::LOGO_SIZE,
               alt: "#{project.title} Project Logo")
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe ApplicationHelper do
 
       expect(img[:src]).to eq(project.logo.url(:standard))
       expect(img[:srcset]).to eq("#{project.logo.url} 2x")
-      expect(img[:width]).to eq('174')
-      expect(img[:height]).to eq('174')
       expect(img[:alt]).to eq("#{project.title} Project Logo")
     end
   end


### PR DESCRIPTION
When project titles were long, they would push the project image up,
instead of the box down. This was undesirable. Here's how I fixed that:

* Change the `height` property on `.project-container` to `min-height`
so it could expand
* Margin on the title from the bottom to the top so it would always
push away from the image

This created a couple other visual glitches:

* Images that aren't square were being forced into that aspect ratio so
I removed the width and height property on the images
* If text happened to wrap just at the edge of the `.project-container`
it would look weird when it touched. I added padding on the left and
right of the container
* Now when titles were multiple lines, they would touch the bottom of
the container, so I added padding to the top and bottom of
`.project-container`