### PR TITLE
Use project images on homepage

### DIFF
--- a/app/assets/stylesheets/_featured-projects.scss
+++ b/app/assets/stylesheets/_featured-projects.scss
@@ -9,7 +9,7 @@
   cursor: pointer;
   flex-direction: column;
   min-height: 260px;
-  padding: $base-spacing 1ex;
+  padding: $small-spacing 1ex;
   margin-bottom: $base-spacing;
 
   @include media($desktop) {

--- a/app/views/projects/_featured.html.erb
+++ b/app/views/projects/_featured.html.erb
@@ -1,4 +1,4 @@
 <div class="project-container">
-  <%= image_tag(nil, alt: featured.title, height: 174, width: 174) %>
+  <%= project_logo(featured) %>
   <h3><%= link_to featured.title, project_path(featured) %></h3>
 </div>


### PR DESCRIPTION
I had implemented the homepage before I had project logos so I added
them to the mix. It revealed a problem though, full height logos
extended the height of the project container. To fix this, I change the
padding on the container to use `small-spacing` instead of
`base-spacing`. After looking back at my designs, this is closer to
what I had planned.