### PR TITLE
Impliment block link

### DIFF
--- a/app/assets/stylesheets/_featured-projects.scss
+++ b/app/assets/stylesheets/_featured-projects.scss
@@ -8,9 +8,10 @@
   border: $border;
   cursor: pointer;
   flex-direction: column;
+  margin-bottom: $base-spacing;
   min-height: 260px;
   padding: $small-spacing 1ex;
-  margin-bottom: $base-spacing;
+  position: relative;
 
   @include media($desktop) {
     @include span-columns(4);
@@ -29,5 +30,9 @@
     a {
       @include header-link-style;
     }
+  }
+
+  .link-target {
+    @include block-link;
   }
 }

--- a/app/assets/stylesheets/_logo.scss
+++ b/app/assets/stylesheets/_logo.scss
@@ -12,10 +12,15 @@ header {
   height: golden-ratio($logo-font-size, 1);
   margin: $base-spacing * 2 auto;
   padding-top: $base-spacing * 1.1;
+  position: relative;
   text-align: center;
 
   img {
     margin: 0 auto;
+  }
+
+  .link-target {
+    @include block-link;
   }
 }
 
@@ -26,11 +31,11 @@ h1 {
   display: inline-block;
   font-size: $logo-font-size;
   height: 1em;
-  pointer-events: none;
   width: 1em;
 }
 
 div.orbit {
+  pointer-events: none;
   @each $i, $size, $delay, $height, $orbit-diameter in
     (1, 4, 0.68, 56, 0.99),
     (2, 8, 0.03, 77, 0.84),

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -4,3 +4,12 @@
   letter-spacing: $letter-spacing-header;
   text-transform: uppercase;
 }
+
+@mixin block-link {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 1;
+}

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,6 +1,9 @@
 <header>
   <h1>
-    <%= title %>
+    <%= link_to root_path do %>
+      <%= title %>
+      <span class="link-target"></span>
+    <% end %>
     <% 20.times do |n| %>
       <%= content_tag(:div, nil, class: ['orbit', "orbit-#{n}"]) %>
     <% end %>

--- a/app/views/projects/_featured.html.erb
+++ b/app/views/projects/_featured.html.erb
@@ -1,4 +1,9 @@
 <div class="project-container">
   <%= project_logo(featured) %>
-  <h3><%= link_to featured.title, project_path(featured) %></h3>
+  <h3>
+    <%= link_to project_path(featured) do %>
+      <%= featured.title %>
+      <span class="link-target"></span>
+    <% end %>
+  </h3>
 </div>


### PR DESCRIPTION
Block links are when I have a block of content, like a featured project
or the logo, that needs to be linked somewhere.

This uses a technique found here:
http://stackoverflow.com/questions/796087/make-a-div-into-a-link#3494108

Inside of the link, you make a <span> tag. This span take gets
positioned absolutely and becomes the full height of the nearest
`position: relative` container. This makes the link the full size of
the container and clickable.