### PR TITLE
Fix mobile header bug

### DIFF
--- a/app/assets/stylesheets/_logo.scss
+++ b/app/assets/stylesheets/_logo.scss
@@ -10,7 +10,7 @@ header, div.orbit {
 
 header {
   height: golden-ratio($logo-font-size, 1);
-  margin: $base-spacing * 2 auto;
+  margin: $base-spacing * 2 auto golden-ratio($base-spacing, 1);
   overflow: hidden;
   padding-top: $base-spacing * 1.1;
   position: relative;

--- a/app/assets/stylesheets/_logo.scss
+++ b/app/assets/stylesheets/_logo.scss
@@ -11,6 +11,7 @@ header, div.orbit {
 header {
   height: golden-ratio($logo-font-size, 1);
   margin: $base-spacing * 2 auto;
+  overflow: hidden;
   padding-top: $base-spacing * 1.1;
   position: relative;
   text-align: center;

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -4,7 +4,7 @@
       <%= title %>
       <span class="link-target"></span>
     <% end %>
-    <% 20.times do |n| %>
+    <% (1..20).each do |n| %>
       <%= content_tag(:div, nil, class: ['orbit', "orbit-#{n}"]) %>
     <% end %>
   </h1>


### PR DESCRIPTION
I have a link to the root of the website in the header. The link content (Edward Loveall) is hidden, but it extends far beyond the bounds of the logo. This was pushing the viewport on small screens out so everything looked like it was pushed on the left side of the screen.

No good.

This adds the `overflow: hidden` property to the header so that any thing that extends outside of it's bounds gets chopped off, visually.

Also, only 19 of the 20 logo dots were showing up. I realized I had a zero-indexed list where I needed a one-index list. Oops!

Also, reduce the bottom margin on the header. This will allow the downward pointing arrow to show up on iPhones with 4" screens, (iPhone 5 family)