### PR TITLE
Add RSpec formatter for Circle CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'i18n-tasks'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rspec_junit_formatter', '0.2.2'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,9 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rspec_junit_formatter (0.2.2)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.4)
@@ -290,6 +293,7 @@ DEPENDENCIES
   rails
   redcarpet
   rspec-rails
+  rspec_junit_formatter (= 0.2.2)
   sass-rails
   shoulda-matchers
   simple_form
@@ -299,5 +303,8 @@ DEPENDENCIES
   uglifier
   webmock
 
+RUBY VERSION
+   ruby 2.2.5p319
+
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
 checkout:
   post:
     - cp .sample.env .env
+database:
+  override:
+    - bin/setup
+test:
+  override:
+    - RAILS_ENV=test bundle exec rspec -r rspec_junit_formatter --format RspecJunitFormatter -o $CIRCLE_TEST_REPORTS/rspec/junit.xml
+    - bundle exec rake bundler:audit


### PR DESCRIPTION
With this formatter, Circle will pretty-print our failures. We need a custom
spec command in `circle.yml` because otherwise Circle only runs RSpec, while
`bundle exec rake` runs `rake bundle:audit` as well.