### PR TITLE
Fix song description overflow

### DIFF
--- a/app/assets/stylesheets/_songs.scss
+++ b/app/assets/stylesheets/_songs.scss
@@ -1,6 +1,6 @@
 section.song {
-  @include clearfix;
-
+  display: flex;
+  flex-direction: column;
   margin-bottom: $large-spacing;
 }
 
@@ -13,7 +13,7 @@ div.song-title {
   }
 }
 
-div.song {
+div.player {
   @include title-card;
 
   padding: $song-padding;
@@ -69,12 +69,25 @@ div.song {
 }
 
 @include media($desktop) {
-  div.song-title {
-    @include span-columns(4);
+  section.song {
+    align-items: flex-start;
+    flex-direction: row;
+    flex-wrap: wrap;
   }
 
-  div.song {
-    @include span-columns(12);
-    @include omega;
+  div.song-title {
+    flex-basis: flex-grid(4);
+    margin-right: flex-gutter();
+    order: 1;
+  }
+
+  div.player {
+    flex-basis: 100%;
+    order: 3;
+  }
+
+  article.description {
+    flex-basis: flex-grid(8);
+    order: 2;
   }
 }

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -2,7 +2,7 @@
   <div class="song-title">
     <h3><%= link_to song.title, song %></h3>
   </div>
-  <div class="song">
+  <div class="player">
     <%= audio_tag(song.audio, controls: false) %>
     <a class="button paused"></a>
     <div class="scrubber">
@@ -13,7 +13,6 @@
     </div>
   </div>
   <article class="copy description">
-    <h4>Description</h4>
     <%= convert_markdown(song.description) %>
   </article>
 </section>

--- a/app/views/songs/index.html.erb
+++ b/app/views/songs/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= content_for(:javascript) do %>
   <script type="text/javascript">
-    var songs = document.querySelectorAll('div.song');
+    var songs = document.querySelectorAll('section.song');
 
     for (var i = 0; i < songs.length; i++) {
       new Song({


### PR DESCRIPTION
When the number of lines in a song's description exceded the height of
the song's title, the extra lines would appear below the player. The
whole layout was a bit hacky anyway and was improved with a rewrite.

I believe the problem was with using neat for float-based layouts. To
fix it, I converted the song layout to use flexbox instead.