### PR TITLE
Update about page to autoplay video on iOS 10 Safari

### DIFF
--- a/app/assets/stylesheets/_about.scss
+++ b/app/assets/stylesheets/_about.scss
@@ -1,15 +1,10 @@
 $portrait-width: 529px;
 
 .about {
-  video.portrait,
-  img.portrait {
+  video.portrait {
     display: block;
     margin: 0 auto golden-ratio($base-spacing, 1);
     max-width: 100%;
-  }
-
-  video.portrait {
-    display: none;
   }
 
   div.copy {
@@ -19,13 +14,5 @@ $portrait-width: 529px;
   article {
     margin: 0 auto;
     max-width: $portrait-width;
-  }
-
-  @include media($desktop) {
-    video.portrait {
-      border: $border;
-      display: block;
-    }
-    img.portrait { display: none; }
   }
 }

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -8,9 +8,9 @@
     autobuffer: true,
     autoplay: true,
     loop: true,
+    playsinline: true,
     class: 'portrait')
   %>
-  <%= image_tag('portrait.jpg', class: 'portrait', alt: 'Edward standing in front of a shopping center with an artificial lake to represent the futility of nature as we humans encroach upon it like a terminal virus.') %>
   <div class="copy">
     <article>
       <h4>About Me</h4>


### PR DESCRIPTION
As of iOS 10 videos that have no audio tracks are allowed to autoplay
in the browser. See this blogpost for more info:
https://webkit.org/blog/6784/new-video-policies-for-ios/