### PR TITLE
Render HTML in rss feeds

### DIFF
--- a/app/views/layouts/blog.erb
+++ b/app/views/layouts/blog.erb
@@ -8,6 +8,7 @@
   <script src="https://use.typekit.net/bts7vjo.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <title><%= title %></title>
+  <%= auto_discovery_link_tag(:rss, rss_url) %>
   <%= stylesheet_link_tag :blog, media: "all" %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/layouts/microblog.html.erb
+++ b/app/views/layouts/microblog.html.erb
@@ -8,6 +8,7 @@
   <script src="https://use.typekit.net/bts7vjo.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <title><%= title %></title>
+  <%= auto_discovery_link_tag(:rss, microposts_feed_url) %>
   <%= stylesheet_link_tag :microblog, media: "all" %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/microposts/feed.rss.builder
+++ b/app/views/microposts/feed.rss.builder
@@ -9,7 +9,7 @@ xml.rss version: '2.0' do
 
     @microposts.each do |micropost|
       xml.item do
-        xml.description micropost.body
+        xml.description convert_markdown(micropost.body)
         xml.link micropost_ms_epoch_url(micropost.ms_epoch)
         xml.pubDate micropost.created_at
         xml.guid micropost.guid, isPermalink: false

--- a/spec/requests/micropost_requests_spec.rb
+++ b/spec/requests/micropost_requests_spec.rb
@@ -26,14 +26,26 @@ RSpec.describe 'Micropost requests' do
 
     it 'has entry attributes' do
       micropost = create(:micropost)
+      body = MarkdownRenderer.to_html(micropost.body)
 
       get microposts_feed_url
       entry = xml[:rss][:channel][:item]
 
       expect(entry[:link]).to eq(micropost_ms_epoch_url(micropost.ms_epoch))
-      expect(entry[:description]).to eq(micropost.body)
+      expect(entry[:description]).to eq(body)
       expect(entry[:pubDate]).to eq(micropost.created_at.to_s)
       expect(entry[:guid]).to eq(micropost.guid)
+    end
+
+    it 'renders the body as html' do
+      body = '[link](https://edwardloveall.com)'
+      html = "<p><a href=\"https://edwardloveall.com\">link</a></p>\n"
+      create(:micropost, body: body)
+
+      get microposts_feed_url
+      entry = xml[:rss][:channel][:item]
+
+      expect(entry[:description]).to eq(html)
     end
 
     it 'reports the guid as a non-permalink' do


### PR DESCRIPTION
They were just the plain markdown text before any html conversion which
is not very nice to read. This renders them as markdown and will
hopefully look nice in RSS readers.

Also, add RSS auto discovery tags for blog/microblog feeds