### PR TITLE
Fix microblog feed title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,6 +61,5 @@ en:
         index: Songs
         new: New song
         edit: Edit %{song}
-    microblog:
-      microposts:
-        feed: Edward Loveall's Microblog
+    microposts:
+      feed: Edward Loveall's Microblog

--- a/spec/requests/micropost_requests_spec.rb
+++ b/spec/requests/micropost_requests_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe 'Micropost requests' do
       channel = rss[:channel]
 
       expect(rss[:version]).to eq('2.0')
+      expect(channel[:title]).to eq("Edward Loveall's Microblog")
       expect(channel[:link]).to eq(microposts_feed_url)
       expect(channel[:lastBuildDate]).to eq(micropost.created_at.to_s)
       expect(channel[:language]).to eq('en-US')


### PR DESCRIPTION
The problem was that the title in I18n was under the microblog
namespace, which was my plan at one time, but didn't pan out. So
removing that was the fix.