### PR TITLE
Microblog styles and scrollDown refactor

### DIFF
--- a/app/assets/javascripts/scrollDown.js
+++ b/app/assets/javascripts/scrollDown.js
@@ -1,12 +1,12 @@
 $(document).ready(function() {
-  var mainStart = $('body > main').offset().top;
+  var nav = $('nav.main');
+  var contentStart = nav.offset().top + nav.outerHeight();
   var windowHeight = $(window).outerHeight();
-  var buffer = 100;
-  var mainThreshold = mainStart / 2;
+  var threshold = windowHeight * .7;
   var instant = 1;
   var referringSite = document.referrer != "";
 
-  if (mainThreshold < windowHeight && referringSite) {
-    $('html, body').animate({ 'scrollTop': mainStart }, instant);
+  if (contentStart > threshold && referringSite) {
+    $('html, body').animate({ 'scrollTop': contentStart }, instant);
   }
 });

--- a/app/assets/stylesheets/microblog/_header.scss
+++ b/app/assets/stylesheets/microblog/_header.scss
@@ -16,9 +16,9 @@ div.microblog-description {
 
   @include media($desktop) {
     p {
-      flex-basis: 50%;
+      flex-basis: 40%;
       margin-bottom: $base-spacing;
-      padding: 0;
+      margin-right: $base-spacing;
     }
   }
 }


### PR DESCRIPTION
First, on the microblog when making each paragraph 50%, there was no space in between them. This allows them to have space while still being flexible. Although, I don't love it and I'd rather there was some way to say 2 paragraphs per row with X space in between.

Second I refactored the code that scrolls the page down so you don't just see a logo on more vertical devices. Hopefully this makes it more clear what's going on and feels better to the user. I'm still not totally in love with this solution, but showing my logo up front is higher priority for me at the moment.