### PR TITLE
Admin redirect

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -6,7 +6,7 @@ class Admin::SessionsController < AdminController
 
   def create
     user = authenticate_session(session_params)
-    destination = params[:original_path] || admin_projects_path
+    destination = session.delete(:original_path) || admin_projects_path
 
     if sign_in(user)
       redirect_to destination

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -6,9 +6,10 @@ class Admin::SessionsController < AdminController
 
   def create
     user = authenticate_session(session_params)
+    destination = params[:original_path] || admin_projects_path
 
     if sign_in(user)
-      redirect_to admin_projects_path
+      redirect_to destination
     else
       render :new
     end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -2,4 +2,15 @@ class AdminController < ApplicationController
   include Monban::ControllerHelpers
   before_action :require_login
   layout 'admin'
+
+  def require_login
+    if !signed_in?
+      flash.notice = Monban.config.sign_in_notice.call
+      original_path = url_for(params.to_h.merge(only_path: true))
+
+      redirect_to(
+        Monban.config.no_login_redirect.merge(original_path: original_path)
+      )
+    end
+  end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,11 +6,9 @@ class AdminController < ApplicationController
   def require_login
     if !signed_in?
       flash.notice = Monban.config.sign_in_notice.call
-      original_path = url_for(params.to_h.merge(only_path: true))
+      session[:original_path] = url_for(params.to_h.merge(only_path: true))
 
-      redirect_to(
-        Monban.config.no_login_redirect.merge(original_path: original_path)
-      )
+      redirect_to Monban.config.no_login_redirect
     end
   end
 end

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,4 +1,5 @@
 <%= simple_form_for :session, url: admin_session_path do |form| %>
+  <%= hidden_field_tag :original_path, params[:original_path] %>
   <%= form.input :email %>
   <%= form.input :password %>
   <%= form.submit 'Sign in' %>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <%= simple_form_for :session, url: admin_session_path do |form| %>
-  <%= hidden_field_tag :original_path, params[:original_path] %>
   <%= form.input :email %>
   <%= form.input :password %>
   <%= form.submit 'Sign in' %>

--- a/spec/features/admin_redirect_spec.rb
+++ b/spec/features/admin_redirect_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Admin redirect" do
+  it "redirects the authenticated admin if there's a redirect url param" do
+    user = create(:user)
+
+    visit new_admin_micropost_path
+
+    expect(current_url).to eq(
+      new_admin_session_url(original_path: new_admin_micropost_path)
+    )
+
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password_digest
+    click_on "Sign in"
+
+    expect(current_url).to eq(new_admin_micropost_url)
+  end
+end

--- a/spec/features/admin_redirect_spec.rb
+++ b/spec/features/admin_redirect_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe "Admin redirect" do
     user = create(:user)
 
     visit new_admin_micropost_path
-
-    expect(current_url).to eq(
-      new_admin_session_url(original_path: new_admin_micropost_path)
-    )
-
     fill_in "Email", with: user.email
     fill_in "Password", with: user.password_digest
     click_on "Sign in"


### PR DESCRIPTION
This will redirect users to the original path they were trying to visit after they sign in. I went through two iterations of this. One passing the original path around in a query parameter, and one storing the original path in the session. The session method won out as it required less pages to be aware of the original path.