### PR TITLE
Token endpoint

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,31 @@
+class TokensController < ApplicationController
+  def create
+    authorization = Authorization.not_code_expired.find_by(
+      code: params[:code],
+      client_id: params[:client_id]
+    )
+    if authorization.present?
+      authorization.generate_token!
+      respond_to do |format|
+        format.json { render json: reply(authorization) }
+        format.url_encoded_form {
+          render plain: form_encoded_response(authorization)
+        }
+      end
+    end
+  end
+
+  private
+
+  def reply(authorization)
+    {
+      me: params[:me],
+      access_token: authorization.token,
+      scope: authorization.scope
+    }
+  end
+
+  def form_encoded_response(authorization)
+    URI.encode_www_form(reply(authorization))
+  end
+end

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -19,7 +19,7 @@ class TokensController < ApplicationController
 
   def reply(authorization)
     {
-      me: params[:me],
+      me: authorization.me,
       access_token: authorization.token,
       scope: authorization.scope
     }

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -17,5 +17,6 @@ class Authorization < ApplicationRecord
   def generate_token!
     self.token = SecureRandom.hex(16)
     self.token_expires_at = 1.year.from_now
+    save
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,10 +1,15 @@
 class Authorization < ApplicationRecord
-  before_create :generate_code
+  before_create :generate_code!
 
   validates_presence_of :client_id
 
-  def generate_code
+  def generate_code!
     self.code = SecureRandom.hex(6)
     self.code_expires_at = 1.day.from_now
+  end
+
+  def generate_token!
+    self.token = SecureRandom.hex(16)
+    self.token_expires_at = 1.year.from_now
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -6,6 +6,7 @@ class Authorization < ApplicationRecord
   delegate :me, to: :user
 
   scope :not_code_expired, -> { where("code_expires_at > NOW()") }
+  scope :not_token_expired, -> { where("token_expires_at > NOW()") }
 
   validates_presence_of :client_id
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -1,6 +1,12 @@
 class Authorization < ApplicationRecord
   before_create :generate_code!
 
+  belongs_to :user
+
+  delegate :me, to: :user
+
+  scope :not_code_expired, -> { where("code_expires_at > NOW()") }
+
   validates_presence_of :client_id
 
   def generate_code!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :authorizations
+
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   get 'experiments', to: 'experiments#index'
   get 'experiments/*path', to: 'experiments#show'
   resources :authorizations, only: [:new, :create], path: "auth"
-  resources :tokens, only: [:create]
+  resources :tokens, only: [:create] do
+    get :verify, on: :collection, path: ""
+  end
   scope :microblog do
     root to: 'microposts#index', as: :microblog
     resources :microposts, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   get 'experiments', to: 'experiments#index'
   get 'experiments/*path', to: 'experiments#show'
   resources :authorizations, only: [:new, :create], path: "auth"
+  resources :tokens, only: [:create]
   scope :microblog do
     root to: 'microposts#index', as: :microblog
     resources :microposts, only: [:index, :show]

--- a/db/migrate/20180522011807_add_token_to_authorization.rb
+++ b/db/migrate/20180522011807_add_token_to_authorization.rb
@@ -1,0 +1,6 @@
+class AddTokenToAuthorization < ActiveRecord::Migration[5.0]
+  def change
+    add_column :authorizations, :token, :string
+    add_column :authorizations, :token_expires_at, :datetime
+  end
+end

--- a/db/migrate/20180527160333_add_me_to_users.rb
+++ b/db/migrate/20180527160333_add_me_to_users.rb
@@ -1,0 +1,5 @@
+class AddMeToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :me, :text
+  end
+end

--- a/db/migrate/20180527170627_authorization_belongs_to_user.rb
+++ b/db/migrate/20180527170627_authorization_belongs_to_user.rb
@@ -1,0 +1,5 @@
+class AuthorizationBelongsToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_belongs_to :authorizations, :user
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180522011807) do
+ActiveRecord::Schema.define(version: 20180527160333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20180522011807) do
     t.datetime "updated_at",      null: false
     t.string   "email",           null: false
     t.string   "password_digest", null: false
+    t.text     "me"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180527160333) do
+ActiveRecord::Schema.define(version: 20180527170627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20180527160333) do
     t.datetime "code_expires_at"
     t.string   "token"
     t.datetime "token_expires_at"
+    t.integer  "user_id"
+    t.index ["user_id"], name: "index_authorizations_on_user_id", using: :btree
   end
 
   create_table "microposts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517142150) do
+ActiveRecord::Schema.define(version: 20180522011807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "authorizations", force: :cascade do |t|
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.string   "client_id",       null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.string   "client_id",        null: false
     t.string   "scope"
     t.string   "code"
     t.datetime "code_expires_at"
+    t.string   "token"
+    t.datetime "token_expires_at"
   end
 
   create_table "microposts", force: :cascade do |t|

--- a/spec/factories/authorization.rb
+++ b/spec/factories/authorization.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :authorization do
+    client_id "https://service.com"
+    scope "create update delete undelete"
+  end
+end

--- a/spec/factories/authorization.rb
+++ b/spec/factories/authorization.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :authorization do
     client_id "https://service.com"
     scope "create update delete undelete"
+    user
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :user do
-    email 'admin@example.com'
-    password_digest 'password'
+    email "admin@example.com"
+    password_digest "password"
+    me "https://edwardloveall.com"
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    email "admin@example.com"
+    sequence(:email) { |n| "admin#{n}@example.com" }
     password_digest "password"
     me "https://edwardloveall.com"
   end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe Authorization do
     end
   end
 
+  describe ".not_token_expired" do
+    it "returns authorizations where tokens aren't expired" do
+      valid = create(:authorization, token_expires_at: 1.year.from_now)
+      expired = create(:authorization, token_expires_at: 1.year.ago)
+
+      results = Authorization.not_token_expired
+
+      expect(results).to include(valid)
+      expect(results).not_to include(expired)
+    end
+  end
+
   describe ".not_code_expired" do
     it "returns authorizations where tokens aren't expired" do
       valid = create(:authorization)

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -11,4 +11,29 @@ RSpec.describe Authorization do
     expect(auth.code).to be
     expect(auth.code_expires_at).to be
   end
+
+  describe "generate_token!" do
+    it "generates a token and token_expires_at" do
+      auth = create(:authorization)
+
+      auth.generate_token!
+      auth.reload
+
+      expect(auth.token).to be
+      expect(auth.token_expires_at).to be
+    end
+  end
+
+  describe ".not_code_expired" do
+    it "returns authorizations where tokens aren't expired" do
+      valid = create(:authorization)
+      expired = create(:authorization)
+      expired.update(code_expires_at: 1.day.ago)
+
+      results = Authorization.not_code_expired
+
+      expect(results).to include(valid)
+      expect(results).not_to include(expired)
+    end
+  end
 end

--- a/spec/requests/token_endpoint_spec.rb
+++ b/spec/requests/token_endpoint_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe "Requesting an initial token" do
+  context "if a valid authorization exists" do
+    context "if the accept header is set to JSON" do
+      it "returns a token" do
+        auth = create(:authorization)
+        me = "https://example.com"
+        params = {
+          code: auth.code,
+          me: me,
+          redirect_uri: "#{auth.client_id}/callback",
+          client_id: auth.client_id
+        }
+        headers = { "Accept" => "application/json" }
+
+        post tokens_path, params: params, headers: headers
+        data = JSON.parse(response.body)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(data["access_token"]).to be
+        expect(data["scope"]).to be
+        expect(data["me"]).to eq(me)
+      end
+    end
+
+    context "if the accept header is set to form encoded" do
+      it "returns a token" do
+        auth = create(:authorization)
+        me = "https://example.com"
+        params = {
+          code: auth.code,
+          me: me,
+          redirect_uri: "#{auth.client_id}/callback",
+          client_id: auth.client_id
+        }
+        headers = { "Accept" => "application/x-www-form-urlencoded" }
+
+        post tokens_path, params: params, headers: headers
+        data = Hash[URI.decode_www_form(response.body)]
+
+        expect(response.content_type).to eq("application/x-www-form-urlencoded")
+        expect(response).to have_http_status(:ok)
+        expect(data["access_token"]).to be
+        expect(data["scope"]).to be
+        expect(data["me"]).to eq(me)
+      end
+    end
+  end
+end

--- a/spec/requests/token_endpoint_spec.rb
+++ b/spec/requests/token_endpoint_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe "Requesting an initial token" do
   context "if a valid authorization exists" do
     context "if the accept header is set to JSON" do
       it "returns a token" do
-        auth = create(:authorization)
         me = "https://example.com"
+        user = create(:user, me: me)
+        auth = create(:authorization, user: user)
         params = {
           code: auth.code,
           me: me,
@@ -27,8 +28,9 @@ RSpec.describe "Requesting an initial token" do
 
     context "if the accept header is set to form encoded" do
       it "returns a token" do
-        auth = create(:authorization)
         me = "https://example.com"
+        user = create(:user, me: me)
+        auth = create(:authorization, user: user)
         params = {
           code: auth.code,
           me: me,

--- a/spec/routing/micropub_token_routing_spec.rb
+++ b/spec/routing/micropub_token_routing_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "microblog token endpoint" do
+  describe "token creation endpoint" do
+    it "routes POST /tokens to tokens#create" do
+      token_creation = { controller: "tokens", action: "create" }
+
+      expect(post: "/tokens").to route_to(token_creation)
+    end
+  end
+
+  describe "token verification endpoint" do
+    it "routes GET /tokens to tokens#verify" do
+      token_verification = { controller: "tokens", action: "verify" }
+
+      expect(get: "/tokens").to route_to(token_verification)
+    end
+  end
+end


### PR DESCRIPTION
The service that the user is attempting to log into will send a post request to this website's token endpoint. That request will include:

* a `code` parameter that matches the code given from the initial Authorization request
* a `client_id` parameter that matches the client ID from the initial Authorization request
* a `me` parameter that identifies the user again
* a `redirect_uri` parameter that matches the redirect uri given from the initial Authorization request

It's a lot of repeat data, but to a different endpoint!

This data can be sent via JSON:

```ruby
{
  code: auth.code,
  me: me,
  redirect_uri: "#{auth.client_id}/callback",
  client_id: auth.client_id
}
```

or as form encoded data:

```
code=abcdef&me=https://example.com&redirect_uri=https://service.com/callback&client_id=https://service.com
```

Either way, we check the data to see if there's an existing authorization present that matches, then we generate a token. This token with some other data is rendered as the response. The response type should match the request type, JSON or form encoded:

```ruby
{
  me: "https://example.com",
  access_token: "a54f2dc223,
  scope: "create update delete undelete"
}
```

I'm not exactly sure what scope should return but I assume it should be the same scope as the authorization.

I'm also currently generating a token expiration date, but I'm not actually checking that yet. Also, the token itself is pretty lame. Needs to be longer and more secure.

---

Also, there is a token verification endpoint. This is a request to the same token endpoint, but it uses the GET verb instead of POST. It's meant to verify an authorization token.

The way it works is the token is sent via the Authorization header, with a Bearer label: `Authorization: Bearer <token>`

If the token exists, it responds with the client_id, me, and scope from the authorization. This can be in either the JSON format or the form encoded format, depending on the Accept header from the request.

---

Other supporting code was needed to make this happen:

* Connecting up Authorizations and Users https://github.com/edwardloveall/portfolio/commit/304601527a2372ba24d1bf4c64f0cedf78ecbefe
* Adding "me" column to Users https://github.com/edwardloveall/portfolio/commit/4400389ea592bc28766dd34a4c06b6cf9a81b894