### PR TITLE
Token endpoint discovery

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
   <link href="https://github.com/edwardloveall" rel="me">
   <link href="https://micro.blog/edwardloveall" rel="me" />
   <link rel="authorization_endpoint" href="<%= new_authorization_url %>">
+  <link rel="token_endpoint" href="<%= tokens_url %>">
   <%= stylesheet_link_tag :application, media: "all" %>
   <%= csrf_meta_tags %>
 </head>

--- a/spec/requests/token_endpoint_spec.rb
+++ b/spec/requests/token_endpoint_spec.rb
@@ -1,5 +1,21 @@
 require "rails_helper"
 
+RSpec.describe "Endpoint discovery" do
+  describe "Token endpoint" do
+    it "can be found as a <link> tag in the <head>" do
+      get root_path
+
+      page = Nokogiri::HTML(response.body)
+      head = page.at("head")
+      token_link = head.xpath("link[@rel='token_endpoint']").first
+
+      expect(token_link).to be
+      expect(token_link[:rel]).to eq("token_endpoint")
+      expect(token_link[:href]).to eq(tokens_url)
+    end
+  end
+end
+
 RSpec.describe "Requesting an initial token" do
   context "if a valid authorization exists" do
     context "if the accept header is set to JSON" do


### PR DESCRIPTION
This is so micropub clients can find the token endpoint by scanning the homepage