### PR TITLE
Add micropub endpoint discovery

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
   <link href="https://micro.blog/edwardloveall" rel="me" />
   <link rel="authorization_endpoint" href="<%= new_authorization_url %>">
   <link rel="token_endpoint" href="<%= tokens_url %>">
+  <link rel="micropub" href="<%= api_micropubs_url %>">
   <%= stylesheet_link_tag :application, media: "all" %>
   <%= csrf_meta_tags %>
 </head>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   resources :tokens, only: [:create] do
     get :verify, on: :collection, path: ""
   end
+  namespace :api do
+    resources :micropubs, only: [:create]
+  end
   scope :microblog do
     root to: 'microposts#index', as: :microblog
     resources :microposts, only: [:index, :show]

--- a/spec/requests/micropub_discovery_spec.rb
+++ b/spec/requests/micropub_discovery_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Endpoint discovery" do
+  describe "Micropub endpoint" do
+    it "can be found as a <link> tag in the <head>" do
+      get root_path
+
+      page = Nokogiri::HTML(response.body)
+      head = page.at("head")
+      micropub_link = head.xpath("link[@rel='micropub']").first
+
+      expect(micropub_link).to be
+      expect(micropub_link[:rel]).to eq("micropub")
+      expect(micropub_link[:href]).to eq(api_micropubs_url)
+    end
+  end
+end


### PR DESCRIPTION
This is extremely minimal for the time being. There is only an
endpoint, no controller or actions yet. This is specifically so I can
get past the mircopub.rocks adding screen and start the tests.