### PR TITLE
Ensure forgery protection is disabled for the token API

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,4 +1,6 @@
 class TokensController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def create
     authorization = Authorization.not_code_expired.find_by(
       code: params[:code],

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.include Features, type: :feature
   config.include Paperclip::Shoulda::Matchers
   config.include S3
+  config.include ForgeryProtectionHelper, type: :request
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false

--- a/spec/requests/token_endpoint_spec.rb
+++ b/spec/requests/token_endpoint_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "Requesting an initial token" do
         }
         headers = { "Accept" => "application/json" }
 
-        post tokens_path, params: params, headers: headers
+        with_forgery_protection do
+          post tokens_path, params: params, headers: headers
+        end
         data = JSON.parse(response.body)
 
         expect(response.content_type).to eq("application/json")
@@ -55,7 +57,9 @@ RSpec.describe "Requesting an initial token" do
         }
         headers = { "Accept" => "application/x-www-form-urlencoded" }
 
-        post tokens_path, params: params, headers: headers
+        with_forgery_protection do
+          post tokens_path, params: params, headers: headers
+        end
         data = Hash[URI.decode_www_form(response.body)]
 
         expect(response.content_type).to eq("application/x-www-form-urlencoded")

--- a/spec/support/forgery_protection_helper.rb
+++ b/spec/support/forgery_protection_helper.rb
@@ -1,0 +1,11 @@
+module ForgeryProtectionHelper
+  def with_forgery_protection
+    orig = ActionController::Base.allow_forgery_protection
+    begin
+      ActionController::Base.allow_forgery_protection = true
+      yield if block_given?
+    ensure
+      ActionController::Base.allow_forgery_protection = orig
+    end
+  end
+end


### PR DESCRIPTION
This requires that `protection_from_forgery` is set on the TokensController. It was passing before because `protection_for_forgery` is disabled when Rails is in test mode.