### PR TITLE
Fix Timeout deprecation warning

### DIFF
--- a/config/initializers/errors.rb
+++ b/config/initializers/errors.rb
@@ -23,7 +23,7 @@ SMTP_SERVER_ERRORS = [
   Net::SMTPAuthenticationError,
   Net::SMTPServerBusy,
   Net::SMTPUnknownError,
-  TimeoutError
+  Timeout::Error
 ].freeze
 
 SMTP_CLIENT_ERRORS = [


### PR DESCRIPTION
Apparently this was super bad and should have been fixed a while ago.

https://jvns.ca/blog/2015/11/27/why-rubys-timeout-is-dangerous-and-threa
d-dot-raise-is-terrifying/