### PR TITLE
Remove active job

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 require 'rails'
 require 'active_model/railtie'
-require 'active_job/railtie'
 require 'active_record/railtie'
 require 'action_controller/railtie'
 require 'action_mailer/railtie'
@@ -22,6 +21,5 @@ module Portfolio
       generate.view_specs false
     end
     config.action_controller.action_on_unpermitted_parameters = :raise
-    config.active_job.queue_adapter = :delayed_job
   end
 end


### PR DESCRIPTION
On the server, I was getting a bunch of "cannot load such file --
delayed_job" errors. I'm not using any kind of queue/job system, so I
don't think I need active job. I suppose we'll find out, but I'm trying
to remove it for now.