### PR TITLE
Create an h-entry micropost with url encoded parameters

### DIFF
--- a/app/controllers/api/micropubs_controller.rb
+++ b/app/controllers/api/micropubs_controller.rb
@@ -1,0 +1,8 @@
+class Api::MicropubsController < ApplicationController
+  protect_from_forgery with: :null_session
+
+  def create
+    micropost = Micropost.create(body: params[:content])
+    head :created, location: micropost_path(micropost)
+  end
+end

--- a/spec/requests/micropub_creation_spec.rb
+++ b/spec/requests/micropub_creation_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Creating an h-entry post" do
+  context "when the Content-type is form encoded" do
+    it "creates a micropost" do
+      auth = create(:authorization)
+      auth.generate_token!
+      headers = {
+        "Authorization" => "Bearer #{auth.token}",
+        "Content-type" => "application/x-www-form-urlencoded; charset=utf-8"
+      }
+      body = {
+        h: "entry",
+        content: "Micropub test of creating a basic h-entry"
+      }
+      micropost_count = Micropost.count
+
+      post api_micropubs_path, params: body, headers: headers
+
+      expect(Micropost.count).to eq(micropost_count + 1)
+      expect(response).to have_http_status(:created)
+      path_matcher = %r(#{microposts_path}/\d+)
+      expect(response.headers["Location"]).to match(path_matcher)
+    end
+  end
+end


### PR DESCRIPTION
A simple h-entry micropost just has text. No attachments or extra metadata like categories.

This defines a way to create an h-entry using application/x-www-form-urlencoded as the Content-type header.