### PR TITLE
Convert logo to z-index

### DIFF
--- a/app/assets/stylesheets/_logo.scss
+++ b/app/assets/stylesheets/_logo.scss
@@ -3,10 +3,27 @@ $diameter: 100% + ($buffer * 2);
 $logo-size: 160px;
 $planet-size: 6px;
 $rotation-period: 10s;
-
-header, div.orbit {
-  transform-style: preserve-3d;
-}
+/* prettier-ignore */
+$orbit-values: (1, 4, 0.68, 56, 0.99),
+(2, 8, 0.03, 77, 0.84),
+(3, 12, 0.23, 48, 1),
+(4, 5, 0.36, 43, 0.99),
+(5, 6, 0.72, 27, 0.89),
+(6, 12, 0.17, 24, 0.86),
+(7, 5, 0.56, 14, 0.69),
+(8, 6, 0.5, 4, 0.39),
+(9, 12, 0.34, 20, 0.8),
+(10, 9, 0.82, 40, 0.98),
+(11, 6, 0.22, 83, 0.75),
+(12, 12, 0.01, 87, 0.67),
+(13, 6, 0.8, 17, 0.76),
+(14, 10, 0.34, 92, 0.53),
+(15, 8, 0.06, 85, 0.71),
+(16, 8, 0.5, 14, 0.7),
+(17, 11, 0.96, 79, 0.82),
+(18, 7, 0.08, 11, 0.63),
+(19, 5, 0.32, 65, 0.96),
+(20, 8, 0.97, 30, 0.92);
 
 header.main {
   box-sizing: border-box;
@@ -31,65 +48,51 @@ h1 {
   display: inline-block;
   font-size: 0;
   height: $logo-size;
-  transform-style: preserve-3d;
+  position: relative;
   width: $logo-size;
 }
 
 div.orbit {
   pointer-events: none;
-  @each $i, $size, $delay, $height, $orbit-diameter in
-    (1, 4, 0.68, 56, 0.99),
-    (2, 8, 0.03, 77, 0.84),
-    (3, 12, 0.23, 48, 1.00),
-    (4, 5, 0.36, 43, 0.99),
-    (5, 6, 0.72, 27, 0.89),
-    (6, 12, 0.17, 24, 0.86),
-    (7, 5, 0.56, 14, 0.69),
-    (8, 6, 0.50, 4, 0.39),
-    (9, 12, 0.34, 20, 0.80),
-    (10, 9, 0.82, 40, 0.98),
-    (11, 6, 0.22, 83, 0.75),
-    (12, 12, 0.01, 87, 0.67),
-    (13, 6, 0.80, 17, 0.76),
-    (14, 10, 0.34, 92, 0.53),
-    (15, 8, 0.06, 85, 0.71),
-    (16, 8, 0.50, 14, 0.70),
-    (17, 11, 0.96, 79, 0.82),
-    (18, 7, 0.08, 11, 0.63),
-    (19, 5, 0.32, 65, 0.96),
-    (20, 8, 0.97, 30, 0.92) {
-      &.orbit-#{$i} {
-        $width: $diameter * $orbit-diameter;
-        $animation-delay: $rotation-period * -$delay;
+  transform: translateX(0%);
+  z-index: 0;
 
-        @include position(absolute, ($height * 1.4% - 20%) 0 0 ((100 - $width) / 2));
-        animation: $rotation-period linear $animation-delay infinite orbit-rotate;
-        width: $width;
+  @each $i, $size, $delay, $height, $orbit-diameter in $orbit-values {
+    &.orbit-#{$i} {
+      $width: $diameter * $orbit-diameter;
+      $delay: $rotation-period * -$delay;
 
-        &:after {
-          animation-delay: $animation-delay;
-          height: $size * 1px;
-          width: $size * 1px;
-        }
+      @include position(
+        absolute,
+        ($height * 1.4% - 20%) 0 0 ((100 - $width) / 2)
+      );
+      animation: $rotation-period ease-in-out $delay infinite orbitPosition,
+        $rotation-period step-end $delay infinite orbitDepth;
+      width: $width;
+
+      &:after {
+        height: $size * 1px;
+        width: $size * 1px;
       }
     }
-
+  }
 }
 
 div.orbit:after {
-  animation: $rotation-period linear infinite planet-rotate;
   background-color: $accent-color;
   border-radius: 50%;
-  content: '';
+  content: "";
   display: block;
 }
 
-@keyframes orbit-rotate {
-  from { transform: rotateY(0deg); }
-  to { transform: rotateY(360deg); }
+@keyframes orbitPosition {
+  50% {
+    transform: translateX(100%);
+  }
 }
 
-@keyframes planet-rotate {
-  from { transform: rotateY(0deg); }
-  to { transform: rotateY(-360deg); }
+@keyframes orbitDepth {
+  50% {
+    z-index: -1;
+  }
 }

--- a/app/views/application/_logo.html.erb
+++ b/app/views/application/_logo.html.erb
@@ -4,6 +4,6 @@
     <span class="link-target"></span>
   <% end %>
   <% (1..20).each do |n| %>
-    <%= content_tag(:div, nil, class: ['orbit', "orbit-#{n}"]) %>
+    <%= content_tag(:div, nil, class: ["orbit", "orbit-#{n}"]) %>
   <% end %>
 </h1>


### PR DESCRIPTION
Instead of using preserve-3d which is less tested, I made the logo
"rotate" by moving left and right in the sine-wave pattern and
front-to-back using z-indexes.

I had to remove the "alternating" direction for the animation because
the z-indexes use a step animation (as opposed to a curve) and stepping
one step with an "alternate" animation has some side effects that I
couldn't figure out. It was easy enough to instead change it to be
twice as long and move back and forth. I also found the nice ability to
set the initial state of the animation in the element itself and then
just specify the 50% mark in the @keyframes. That made the keyframes
much smaller and has the side-effect of making the end state the same
as the start state.