### PR TITLE
Fix admin css

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -9,7 +9,7 @@
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
   <title><%= title %></title>
   <%= favicon_link_tag('favicon.png') %>
-  <%= stylesheet_pack_tag 'admin/admin' %>
+  <%= stylesheet_pack_tag :admin %>
   <%= javascript_pack_tag :admin %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
I had a production incident where my admin css page would not load. The
error was that I had a stylesheet_pack_tag pointing toward
'admin/admin' because the root css file exists in
app/assets/stylesheets/admin/admin.scss and most rails conventions use
the namespaced path (path from app/assets/stylesheets).

I'm not sure why, but it seems that webpacker doesn't namespace the
output, or  at least stylesheet_pack_tag doesn't look for a namespaced
image.

I debugged this by changing `extract_css` to `false` in the
config/webpacker.yml file. Then ran `rails webpacker:clobber` followed
by `rails webpacker:compile` and restarted the server.

To convert back to development testing, I turned `extract_css` back to
`true` and clobbered the assets again and restarted the server.