### PR TITLE
Fix logo left side

### DIFF
--- a/app/assets/stylesheets/_logo.scss
+++ b/app/assets/stylesheets/_logo.scss
@@ -59,11 +59,13 @@ div.orbit {
   @each $i, $size, $delay, $top-offset, $orbit-diameter in $orbit-values {
     &.orbit-#{$i} {
       $delay: $rotation-period * -$delay;
+      $orbit-diameter-px: $logo-width * ($orbit-diameter / 100%);
 
       animation: $rotation-period ease-in-out $delay infinite orbitPosition,
         $rotation-period step-end $delay infinite orbitDepth;
       position: absolute;
       top: $top-offset;
+      left: ($logo-width - $orbit-diameter-px) / 2;
       width: $orbit-diameter;
 
       &:after {


### PR DESCRIPTION
When I modified the logo last time, I removed the left-side offset. All
the planets had a skewed orbit that aligned on the left like lines in a
paragraph.

The fix was to offset them again by:

Converting each orbit width to a pixel value (percentage of logo width)
Subtracting each orbit from the logo width
Dividing that difference by 2

A conversion from percentage to pixels was necessary because pixels and
percentages can't be calculated together in SASS. I could have also
figured out the values and hard coded them.