### PR TITLE
Add teasers to internal posts

### DIFF
--- a/app/controllers/admin/internal_posts_controller.rb
+++ b/app/controllers/admin/internal_posts_controller.rb
@@ -47,7 +47,7 @@ class Admin::InternalPostsController < AdminController
   private
 
   def internal_post_params
-    params.require(:internal_post).permit(:title, :body, :slug)
+    params.require(:internal_post).permit(:body, :slug, :teaser, :title)
   end
 
   def find_internal_post

--- a/app/models/internal_post.rb
+++ b/app/models/internal_post.rb
@@ -2,8 +2,9 @@ class InternalPost < ApplicationRecord
   has_one :post, as: :postable
 
   validates :body, presence: true
-  validates :title, presence: true
   validates :slug, presence: true, uniqueness: true
+  validates :teaser, presence: true
+  validates :title, presence: true
 
   scope :newest_first, lambda { order(created_at: :desc) }
 

--- a/app/views/admin/internal_posts/_form.html.erb
+++ b/app/views/admin/internal_posts/_form.html.erb
@@ -4,6 +4,7 @@
   <div class="form-inputs">
     <%= form.input :title %>
     <%= form.input :slug %>
+    <%= form.input :teaser %>
     <%= form.input :body %>
   </div>
 

--- a/db/migrate/20220326141243_add_teaser_to_internal_posts.rb
+++ b/db/migrate/20220326141243_add_teaser_to_internal_posts.rb
@@ -1,0 +1,5 @@
+class AddTeaserToInternalPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:internal_posts, :teaser, :text, default: "", null: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_24_181744) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_26_141243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_24_181744) do
     t.text "body"
     t.string "slug"
     t.string "tumblr_guid"
+    t.text "teaser", default: "", null: false
   end
 
   create_table "posts", force: :cascade do |t|

--- a/spec/factories/internal_posts.rb
+++ b/spec/factories/internal_posts.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "A Scary Story" }
     body { "It was a dark and stormy night..." }
     sequence(:slug) { |n| "a-scary-story-#{n}" }
+    teaser { "Get ready to be scared!" }
   end
 end

--- a/spec/models/internal_post_spec.rb
+++ b/spec/models/internal_post_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe InternalPost, type: :model do
   describe "validations" do
     it { should validate_presence_of(:body) }
-    it { should validate_presence_of(:title) }
     it { should validate_presence_of(:slug) }
     it { should validate_uniqueness_of(:slug) }
+    it { should validate_presence_of(:teaser) }
+    it { should validate_presence_of(:title) }
   end
 
   describe ".newest_first" do


### PR DESCRIPTION
Instead of showing posts in full on the post index page, this sets up
the ability to have teaser text with the titles and dates.