### PR TITLE
Fix individual post view

### DIFF
--- a/app/controllers/internal_posts_controller.rb
+++ b/app/controllers/internal_posts_controller.rb
@@ -1,4 +1,6 @@
 class InternalPostsController < ApplicationController
+  layout "blog"
+
   def show
     @internal_post = InternalPost.find_by(slug: params[:slug])
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  layout 'blog'
+  layout "blog"
 
   def index
     page = params[:page] || 1

--- a/spec/features/user_visits_posts_spec.rb
+++ b/spec/features/user_visits_posts_spec.rb
@@ -17,6 +17,22 @@ feature "User visits posts" do
     expect(page).to have_link("Newer", href: root_path)
   end
 
+  scenario "sees styled posts", :js do
+    title_red = "rgba(233, 85, 85, 1)"
+    time_font_size = "12px"
+    body_font_style = "normal"
+    post = create(:post, postable: create(:internal_post, title: "Title"))
+
+    visit root_url(subdomain: "blog")
+
+    title = page.find("article h2 a", text: "Title")
+    timestamp = page.find("article aside time")
+    body_paragraph = page.find("article p", match: :first)
+    expect(title).to match_style("color" => title_red)
+    expect(timestamp).to match_style("font-size" => time_font_size)
+    expect(body_paragraph).to match_style("font-style" => body_font_style)
+  end
+
   scenario "can visit main site from footer" do
     visit root_url(subdomain: "blog")
 
@@ -30,7 +46,24 @@ feature "User visits posts" do
 end
 
 feature "User visits a specific post" do
-  scenario "and sees a post rendered with markdown" do
+  scenario "sees a styled post", :js do
+    title_red = "rgba(233, 85, 85, 1)"
+    time_font_size = "12px"
+    body_font_style = "normal"
+    post = create(:post, postable: create(:internal_post, title: "Title"))
+
+    visit root_url(subdomain: "blog")
+    click_on("Title")
+
+    title = page.find("article h2 a", text: "Title")
+    timestamp = page.find("article aside time")
+    body_paragraph = page.find("article p", match: :first)
+    expect(title).to match_style("color" => title_red)
+    expect(timestamp).to match_style("font-size" => time_font_size)
+    expect(body_paragraph).to match_style("font-style" => body_font_style)
+  end
+
+  scenario "sees a post rendered with markdown" do
     internal_post = create(
       :internal_post,
       title: "Title",

--- a/spec/features/user_visits_posts_spec.rb
+++ b/spec/features/user_visits_posts_spec.rb
@@ -1,41 +1,51 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.feature 'User visits posts' do
-  scenario 'and sees pagination links' do
+feature "User visits posts" do
+  scenario "and sees next page pagination links" do
     create_list(:post, 11)
 
-    visit root_url(subdomain: 'blog')
+    visit root_url(subdomain: "blog")
 
-    expect(page).to have_link('Older', href: root_path(page: 2))
+    expect(page).to have_link("Older", href: root_path(page: 2))
   end
 
-  scenario 'and sees pagination links' do
+  scenario "and sees previous page pagination links" do
     create_list(:post, 11)
 
-    visit root_url(subdomain: 'blog', page: 2)
+    visit root_url(subdomain: "blog", page: 2)
 
-    expect(page).to have_link('Newer', href: root_path)
+    expect(page).to have_link("Newer", href: root_path)
   end
 
-  scenario "and visits a specific post" do
-    internal_post = create(:internal_post, title: "Title")
+  scenario "can visit main site from footer" do
+    visit root_url(subdomain: "blog")
+
+    within("footer") do
+      expect(page).to have_link(
+        "Edward Loveall",
+        href: "https://edwardloveall.com",
+      )
+    end
+  end
+end
+
+feature "User visits a specific post" do
+  scenario "and sees a post rendered with markdown" do
+    internal_post = create(
+      :internal_post,
+      title: "Title",
+      body: "_hello_",
+      slug: "title"
+    )
     post = create(:post, postable: internal_post)
 
     visit root_url(subdomain: "blog")
     click_on("Title")
 
     expect(current_url).to eq(
-      internal_post_url(subdomain: "blog", slug: internal_post.slug)
+      internal_post_url(subdomain: "blog", slug: "title")
     )
     expect(page).to have_selector("article h2", text: "Title")
-  end
-
-  scenario 'can visit main site from footer' do
-    visit root_url(subdomain: 'blog')
-
-    within('footer') do
-      expect(page).to have_link('Edward Loveall',
-                                href: 'https://edwardloveall.com')
-    end
+    expect(page).to have_selector("article em", text: "hello")
   end
 end


### PR DESCRIPTION
I first thought this was markdown so I updated the feature post spec (it's now improved but unrelated to the fix). Then I discovered that it's because `InternalPostsController` was using the default application layout instead of the `blog` layout. Easy fix, but what about the test?

I first tried to use a controller test. However, asserting that a specific layout is used is deprecated: https://github.com/rails/rails/pull/20138 Then I tried a feature spec. This works, but I'm still just testing things unrelated to what I care about. In particular, the main navigation exists in the application layout, but not in the blog layout. That works for now, but it still didn't feel like the right way to test if a post has the correct styles applied to it.

I landed on actually asserting on the styles using Capybara's [`matches_style`](https://rubydoc.info/github/teamcapybara/capybara/master/Capybara%2FNode%2FMatchers:matches_style%3F) matcher. This requires that I use a non-headless browser to render the CSS styles of a page.