### PR TITLE
Fix circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run:
           name: Build assets
-          command: yarn build
+          command: "bundle exec rails assets:precompile"
 
       # Save dependency cache
       - save_cache:


### PR DESCRIPTION
The fix was to build assets with `rails assets:precompile` instead of `yarn build`. Because I switched back to building assets with the asset pipeline not esbuild, CI needed to also have that configured.