### PR TITLE
Use browser-tools orb to install browser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  browser-tools: circleci/browser-tools@1.4.1
+
 jobs:
   build:
     parallelism: 1
@@ -17,11 +21,8 @@ jobs:
 
     steps:
       - checkout
-      - run:
-          name: Setup Chrome
-          command: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo apt install ./google-chrome-stable_current_amd64.deb
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Create Directories
           command: mkdir -p test-results


### PR DESCRIPTION
All of a sudden, installing chrome manually stopped working. I am trying circle ci's orbs instead.

https://circleci.com/developer/orbs/orb/circleci/browser-tools